### PR TITLE
fix integer overflow by using more clearer code

### DIFF
--- a/hokuyo.cc
+++ b/hokuyo.cc
@@ -520,7 +520,7 @@ bool URG::measureCommunicationLatency(int timeout)
     if (!simpleCommand(URG_TM2, timeout))
 	return false;
 
-    device_time_offset = t1/2+t2/2-base::Time::fromMicroseconds(ts*1000);
+    device_time_offset = t1/2+t2/2-base::Time::fromMilliseconds(ts);
     return true;
 }
 
@@ -682,7 +682,7 @@ bool URG::readRanges(base::samples::LaserScan& range, int timeout)
 
     // subtract 3.1 ms for the difference between "back of the scanner"
     // and measurement 0
-    range.time = device_time_offset+base::Time::fromMicroseconds(device_timestamp*1000-3100);
+    range.time = device_time_offset + base::Time::fromMilliseconds(device_timestamp) - base::Time::fromMicroseconds(3100);
 
     //period of the device
     base::Time period = base::Time::fromSeconds(1.0 / (range.speed / (M_PI * 2.0)));


### PR DESCRIPTION
reported by `-fsanitize=undefined` while calling `./hokuyo_test uri tcp://10.250.8.169:10940`

did not test for functionality of the actual scan. and I do not know what sideeffects the previous overflow caused.

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
